### PR TITLE
🔄 JWT 리프레시 토큰 기능 구현

### DIFF
--- a/src/domain/repositories/jwt.repository.ts
+++ b/src/domain/repositories/jwt.repository.ts
@@ -2,4 +2,5 @@ import { AuthTokens } from '@/domain/entities';
 
 export interface IJwtRepository {
   generateTokens(userId: string): Promise<AuthTokens>;
+  validateRefreshToken(refreshToken: string): Promise<{ userId: string } | null>;
 }

--- a/src/domain/use-cases/index.ts
+++ b/src/domain/use-cases/index.ts
@@ -1,3 +1,4 @@
 export * from './health.use-case';
 export * from './welcome.use-case';
 export * from './account.use-case';
+export * from './refresh-token.use-case';

--- a/src/domain/use-cases/refresh-token.use-case.ts
+++ b/src/domain/use-cases/refresh-token.use-case.ts
@@ -1,0 +1,20 @@
+import { AuthTokens } from '@/domain/entities';
+import { IJwtRepository } from '@/domain/repositories';
+
+export interface IRefreshTokenUseCase {
+  execute(refreshToken: string): Promise<AuthTokens | null>;
+}
+
+export class RefreshTokenUseCase implements IRefreshTokenUseCase {
+  constructor(private readonly jwtRepository: IJwtRepository) {}
+
+  async execute(refreshToken: string): Promise<AuthTokens | null> {
+    const validationResult = await this.jwtRepository.validateRefreshToken(refreshToken);
+    
+    if (!validationResult) {
+      return null;
+    }
+
+    return await this.jwtRepository.generateTokens(validationResult.userId);
+  }
+}

--- a/src/infrastructure/services/jwt.service.ts
+++ b/src/infrastructure/services/jwt.service.ts
@@ -25,4 +25,18 @@ export class JwtService implements IJwtRepository {
 
     return new AuthTokens(accessToken, refreshToken);
   }
+
+  async validateRefreshToken(refreshToken: string): Promise<{ userId: string } | null> {
+    try {
+      const decoded = jwt.verify(refreshToken, this.secretKey) as any;
+      
+      if (decoded.type !== 'refresh') {
+        return null;
+      }
+      
+      return { userId: decoded.userId };
+    } catch (error) {
+      return null;
+    }
+  }
 }

--- a/src/presentation/routes/account.routes.ts
+++ b/src/presentation/routes/account.routes.ts
@@ -10,6 +10,7 @@ export class AccountRoutes {
 
   private initializeRoutes(): void {
     this.router.post('/', (req, res) => this.accountController.createAccount(req, res));
+    this.router.post('/refresh', (req, res) => this.accountController.refreshToken(req, res));
   }
 
   getRouter(): Router {

--- a/src/shared/types/response.ts
+++ b/src/shared/types/response.ts
@@ -26,3 +26,7 @@ export interface AuthTokensResponse {
   accessToken: string;
   refreshToken: string;
 }
+
+export interface RefreshTokenRequest {
+  refreshToken: string;
+}

--- a/src/shared/utils/container.ts
+++ b/src/shared/utils/container.ts
@@ -1,4 +1,4 @@
-import { HealthUseCase, WelcomeUseCase, IHealthUseCase, IWelcomeUseCase, CreateAccountUseCase, ICreateAccountUseCase } from '@/domain/use-cases';
+import { HealthUseCase, WelcomeUseCase, IHealthUseCase, IWelcomeUseCase, CreateAccountUseCase, ICreateAccountUseCase, RefreshTokenUseCase, IRefreshTokenUseCase } from '@/domain/use-cases';
 import { IAccountRepository, ISystemRepository, IJwtRepository } from '@/domain/repositories';
 import { ConsoleLoggerService, ILoggerService, DatabaseService, SystemService, PrismaService, PrismaAccountService, JwtService } from '@/infrastructure/services';
 import { IDatabaseService } from '@/shared/types';
@@ -38,12 +38,16 @@ export class Container {
       this.get<IAccountRepository>('accountRepository'),
       this.get<IJwtRepository>('jwtRepository')
     ));
+    this.services.set('refreshTokenUseCase', new RefreshTokenUseCase(this.get<IJwtRepository>('jwtRepository')));
 
     // Controllers
     this.services.set('healthController', new HealthController(this.get<IHealthUseCase>('healthUseCase')));
     this.services.set('welcomeController', new WelcomeController(this.get<IWelcomeUseCase>('welcomeUseCase')));
     this.services.set('databaseController', new DatabaseController(this.get<IDatabaseService>('database')));
-    this.services.set('accountController', new AccountController(this.get<ICreateAccountUseCase>('createAccountUseCase')));
+    this.services.set('accountController', new AccountController(
+      this.get<ICreateAccountUseCase>('createAccountUseCase'),
+      this.get<IRefreshTokenUseCase>('refreshTokenUseCase')
+    ));
 
     // Middlewares
     this.services.set('errorMiddleware', new ErrorMiddleware(this.get<ILoggerService>('logger')));


### PR DESCRIPTION
  🔄 JWT 리프레시 토큰 API 구현

  주요 변경사항

  - JWT 토큰 갱신 기능: 만료된 액세스 토큰을 리프레시 토큰으로 갱신하는 API 추가
  - 새로운 엔드포인트: POST /accounts/refresh 구현
  - 토큰 검증 로직: 리프레시 토큰의 유효성 검사 및 타입 확인 기능 추가

  구현 내용

  - IJwtRepository에 validateRefreshToken 메서드 추가
  - JwtService에서 JWT 토큰 검증 및 디코딩 구현
  - RefreshTokenUseCase 생성으로 비즈니스 로직 분리
  - AccountController에 토큰 갱신 엔드포인트 추가
  - Clean Architecture 패턴에 따른 의존성 주입 구조 적용

  API 스펙

  요청: POST /accounts/refresh
  { "refreshToken": "리프레시_토큰" }

  응답: 새로운 액세스 토큰과 리프레시 토큰 반환

  에러 처리

  - 누락된 리프레시 토큰: 400 Bad Request
  - 유효하지 않거나 만료된 토큰: 401 Unauthorized
  - 서버 오류: 500 Internal Server Error