### PR TITLE
내 계정 조회 API 추가

### DIFF
--- a/src/domain/use-cases/account.use-case.ts
+++ b/src/domain/use-cases/account.use-case.ts
@@ -1,8 +1,12 @@
-import { AccountType, AuthTokens } from '@/domain/entities';
+import { Account, AccountType, AuthTokens } from '@/domain/entities';
 import { IAccountRepository, IJwtRepository } from '@/domain/repositories';
 
 export interface ICreateAccountUseCase {
   execute(id: string, type: AccountType): Promise<AuthTokens>;
+}
+
+export interface IGetAccountUseCase {
+  execute(id: string): Promise<Account | null>;
 }
 
 export class CreateAccountUseCase implements ICreateAccountUseCase {
@@ -22,5 +26,15 @@ export class CreateAccountUseCase implements ICreateAccountUseCase {
 
     // Generate and return tokens for the user
     return await this.jwtRepository.generateTokens(id);
+  }
+}
+
+export class GetAccountUseCase implements IGetAccountUseCase {
+  constructor(
+    private accountRepository: IAccountRepository
+  ) {}
+
+  async execute(id: string): Promise<Account | null> {
+    return await this.accountRepository.findById(id);
   }
 }

--- a/src/presentation/middlewares/auth.middleware.ts
+++ b/src/presentation/middlewares/auth.middleware.ts
@@ -1,0 +1,50 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { ApiResponse } from '@/shared/types';
+
+interface AuthenticatedRequest extends Request {
+  userId?: string;
+}
+
+export class AuthMiddleware {
+  private static secretKey = process.env.JWT_SECRET || 'your-secret-key-here';
+
+  static verifyToken(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
+    try {
+      const authHeader = req.headers.authorization;
+      
+      if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        const response: ApiResponse<null> = {
+          success: false,
+          error: 'Authorization token is required'
+        };
+        res.status(401).json(response);
+        return;
+      }
+
+      const token = authHeader.substring(7); // Remove 'Bearer ' prefix
+
+      const decoded = jwt.verify(token, AuthMiddleware.secretKey) as any;
+      
+      if (decoded.type !== 'access') {
+        const response: ApiResponse<null> = {
+          success: false,
+          error: 'Invalid token type'
+        };
+        res.status(401).json(response);
+        return;
+      }
+
+      req.userId = decoded.userId;
+      next();
+    } catch (error) {
+      const response: ApiResponse<null> = {
+        success: false,
+        error: 'Invalid or expired token'
+      };
+      res.status(401).json(response);
+    }
+  }
+}
+
+export { AuthenticatedRequest };

--- a/src/presentation/routes/account.routes.ts
+++ b/src/presentation/routes/account.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { AccountController } from '@/presentation/controllers';
+import { AuthMiddleware } from '@/presentation/middlewares/auth.middleware';
 
 export class AccountRoutes {
   private router = Router();
@@ -11,6 +12,7 @@ export class AccountRoutes {
   private initializeRoutes(): void {
     this.router.post('/', (req, res) => this.accountController.createAccount(req, res));
     this.router.post('/refresh', (req, res) => this.accountController.refreshToken(req, res));
+    this.router.get('/me', AuthMiddleware.verifyToken, (req, res) => this.accountController.getAccount(req, res));
   }
 
   getRouter(): Router {

--- a/src/shared/utils/container.ts
+++ b/src/shared/utils/container.ts
@@ -1,4 +1,4 @@
-import { HealthUseCase, WelcomeUseCase, IHealthUseCase, IWelcomeUseCase, CreateAccountUseCase, ICreateAccountUseCase, RefreshTokenUseCase, IRefreshTokenUseCase } from '@/domain/use-cases';
+import { HealthUseCase, WelcomeUseCase, IHealthUseCase, IWelcomeUseCase, CreateAccountUseCase, ICreateAccountUseCase, GetAccountUseCase, IGetAccountUseCase, RefreshTokenUseCase, IRefreshTokenUseCase } from '@/domain/use-cases';
 import { IAccountRepository, ISystemRepository, IJwtRepository } from '@/domain/repositories';
 import { ConsoleLoggerService, ILoggerService, DatabaseService, SystemService, PrismaService, PrismaAccountService, JwtService } from '@/infrastructure/services';
 import { IDatabaseService } from '@/shared/types';
@@ -38,6 +38,7 @@ export class Container {
       this.get<IAccountRepository>('accountRepository'),
       this.get<IJwtRepository>('jwtRepository')
     ));
+    this.services.set('getAccountUseCase', new GetAccountUseCase(this.get<IAccountRepository>('accountRepository')));
     this.services.set('refreshTokenUseCase', new RefreshTokenUseCase(this.get<IJwtRepository>('jwtRepository')));
 
     // Controllers
@@ -46,6 +47,7 @@ export class Container {
     this.services.set('databaseController', new DatabaseController(this.get<IDatabaseService>('database')));
     this.services.set('accountController', new AccountController(
       this.get<ICreateAccountUseCase>('createAccountUseCase'),
+      this.get<IGetAccountUseCase>('getAccountUseCase'),
       this.get<IRefreshTokenUseCase>('refreshTokenUseCase')
     ));
 


### PR DESCRIPTION
⏺ Summary

  • JWT token authentication middleware - Authorization header에서 Bearer token을 검증하고 사용자 ID를 추출
  • Account retrieval use case - 토큰에서 추출한 사용자 ID로 계정 정보를 조회하는 비즈니스 로직
  • GET /accounts/me endpoint - 인증된 사용자의 계정 정보를 반환 (Profile 및 QnA 포함)
  • Clean Architecture patterns - 도메인, 인프라, 프레젠테이션 레이어 분리 및 DI 컨테이너 활용

  Test plan

  - POST /accounts로 계정 생성하여 accessToken 획득
  - GET /accounts/me에 Bearer token으로 요청하여 계정 정보 조회 확인
  - 잘못된/만료된 토큰으로 401 Unauthorized 응답 확인
  - Authorization header 없이 요청하여 401 응답 확인
  - 존재하지 않는 사용자 토큰으로 404 응답 확인