### PR TITLE
✨ 한글 전용 닉네임 업데이트 API 추가

### DIFF
--- a/src/domain/repositories/profile.repository.ts
+++ b/src/domain/repositories/profile.repository.ts
@@ -4,5 +4,6 @@ export interface IProfileRepository {
   findById(id: string): Promise<Profile | null>;
   findByAccountId(accountId: string): Promise<Profile | null>;
   updateProfileImage(accountId: string, imageUrl: string): Promise<Profile>;
+  updateNickname(accountId: string, nickname: string): Promise<Profile>;
   update(id: string, data: Partial<Profile>): Promise<Profile>;
 }

--- a/src/domain/use-cases/profile.use-case.ts
+++ b/src/domain/use-cases/profile.use-case.ts
@@ -1,8 +1,10 @@
 import { IProfileRepository, IImageRepository } from '../repositories';
 import { Profile } from '../entities';
+import { validateKoreanNickname } from '@/shared/utils';
 
 export interface IProfileUseCase {
   updateProfileImage(accountId: string, imageFile: Buffer, fileName: string): Promise<Profile>;
+  updateNickname(accountId: string, nickname: string): Promise<Profile>;
   getProfile(accountId: string): Promise<Profile | null>;
 }
 
@@ -18,6 +20,25 @@ export class ProfileUseCase implements IProfileUseCase {
     
     // Update profile with new image URL
     const updatedProfile = await this.profileRepository.updateProfileImage(accountId, imageUrl);
+    
+    return updatedProfile;
+  }
+
+  async updateNickname(accountId: string, nickname: string): Promise<Profile> {
+    // Validate Korean nickname
+    const validation = validateKoreanNickname(nickname);
+    if (!validation.isValid) {
+      throw new Error(validation.error);
+    }
+
+    // Check if profile exists
+    const existingProfile = await this.profileRepository.findByAccountId(accountId);
+    if (!existingProfile) {
+      throw new Error('Profile not found');
+    }
+
+    // Update nickname
+    const updatedProfile = await this.profileRepository.updateNickname(accountId, nickname);
     
     return updatedProfile;
   }

--- a/src/infrastructure/services/prisma-profile.service.ts
+++ b/src/infrastructure/services/prisma-profile.service.ts
@@ -39,6 +39,18 @@ export class PrismaProfileService implements IProfileRepository {
     return updatedProfile as Profile;
   }
 
+  async updateNickname(accountId: string, nickname: string): Promise<Profile> {
+    const updatedProfile = await this.prisma.profile.update({
+      where: { accountId },
+      data: { nickname },
+      include: {
+        qnas: true
+      }
+    });
+
+    return updatedProfile as Profile;
+  }
+
   async update(id: string, data: Partial<Profile>): Promise<Profile> {
     const updatedProfile = await this.prisma.profile.update({
       where: { id },

--- a/src/presentation/controllers/profile.controller.ts
+++ b/src/presentation/controllers/profile.controller.ts
@@ -77,6 +77,47 @@ export class ProfileController {
     }
   };
 
+  public updateNickname = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    try {
+      const accountId = req.userId;
+      const { nickname } = req.body;
+
+      if (!accountId) {
+        const response: ApiResponse<null> = {
+          success: false,
+          error: 'Authentication required'
+        };
+        res.status(401).json(response);
+        return;
+      }
+
+      if (!nickname) {
+        const response: ApiResponse<null> = {
+          success: false,
+          error: 'Nickname is required'
+        };
+        res.status(400).json(response);
+        return;
+      }
+
+      const updatedProfile = await this.profileUseCase.updateNickname(accountId, nickname);
+
+      const response: ApiResponse<Profile> = {
+        success: true,
+        data: updatedProfile,
+        message: 'Nickname updated successfully'
+      };
+
+      res.status(200).json(response);
+    } catch (error) {
+      const response: ApiResponse<null> = {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to update nickname'
+      };
+      res.status(500).json(response);
+    }
+  };
+
   public getProfile = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     try {
       const accountId = req.userId;

--- a/src/presentation/routes/profile.routes.ts
+++ b/src/presentation/routes/profile.routes.ts
@@ -21,5 +21,8 @@ export class ProfileRoutes {
       this.profileController.uploadMiddleware,
       this.profileController.uploadProfileImage
     );
+
+    // PATCH /profiles/nickname - Update current user nickname
+    this.router.patch('/nickname', AuthMiddleware.verifyToken, this.profileController.updateNickname);
   }
 }

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './container';
 export * from './nickname-generator';
+export * from './korean-validator';

--- a/src/shared/utils/korean-validator.ts
+++ b/src/shared/utils/korean-validator.ts
@@ -1,0 +1,61 @@
+/**
+ * 한글 닉네임 유효성 검사 유틸리티
+ * 한글만 허용, 공백 및 특수문자 불허
+ */
+
+/**
+ * 한글 문자열인지 검사합니다
+ * 한글 자모, 완성형 한글만 허용 (ㄱ-ㅎ, ㅏ-ㅣ, 가-힣)
+ * @param text 검사할 문자열
+ * @returns 한글만 포함된 경우 true
+ */
+export function isKoreanOnly(text: string): boolean {
+  // 빈 문자열 체크
+  if (!text || text.trim().length === 0) {
+    return false;
+  }
+
+  // 한글 유니코드 범위: 자음(ㄱ-ㅎ), 모음(ㅏ-ㅣ), 완성형 한글(가-힣)
+  const koreanRegex = /^[ㄱ-ㅎㅏ-ㅣ가-힣]+$/;
+  
+  return koreanRegex.test(text);
+}
+
+/**
+ * 닉네임 유효성을 검사합니다
+ * @param nickname 검사할 닉네임
+ * @param minLength 최소 길이 (기본값: 2)
+ * @param maxLength 최대 길이 (기본값: 50)
+ * @returns 유효성 검사 결과
+ */
+export function validateKoreanNickname(
+  nickname: string,
+  minLength: number = 2,
+  maxLength: number = 50
+): { isValid: boolean; error?: string } {
+  // 빈 값 체크
+  if (!nickname) {
+    return { isValid: false, error: '닉네임을 입력해주세요.' };
+  }
+
+  // 길이 체크
+  if (nickname.length < minLength) {
+    return { isValid: false, error: `닉네임은 최소 ${minLength}자 이상이어야 합니다.` };
+  }
+
+  if (nickname.length > maxLength) {
+    return { isValid: false, error: `닉네임은 최대 ${maxLength}자까지 가능합니다.` };
+  }
+
+  // 공백 체크
+  if (nickname.includes(' ')) {
+    return { isValid: false, error: '닉네임에 공백을 포함할 수 없습니다.' };
+  }
+
+  // 한글만 허용 체크
+  if (!isKoreanOnly(nickname)) {
+    return { isValid: false, error: '닉네임은 한글만 사용 가능합니다.' };
+  }
+
+  return { isValid: true };
+}


### PR DESCRIPTION
사용자가 자신의 닉네임을 한글로만 업데이트할 수 있는 새로운 API 엔드포인트를 구현했습니다.

주요 기능:
- PATCH /profiles/nickname 엔드포인트
- 한글 전용 유효성 검사 (공백, 특수문자, 영문 불허)
- JWT 토큰 기반 인증 필수
- 2-50자 길이 제한
- 상세한 한국어 오류 메시지

🤖 Generated with [Claude Code](https://claude.ai/code)